### PR TITLE
Fix dep to maintained version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(name='talon',
           "scipy",
           "scikit-learn==0.16.1", # pickled versions of classifier, else rebuild
           'chardet>=1.0.1',
-          'cchardet>=0.3.5',
+          'charset-normalizer',
+          # 'cchardet>=0.3.5',  # replaced by charset-normalizer
           'cssselect',
           'six>=1.10.0',
           'html5lib'

--- a/talon/utils.py
+++ b/talon/utils.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from random import shuffle
 
-import cchardet
+import charset_normalizer as cchardet
 import chardet
 import html5lib
 import regex as re
@@ -74,7 +74,7 @@ def quick_detect_encoding(string):
     """
     Tries to detect the encoding of the passed string.
 
-    Uses cchardet. Fallbacks to detect_encoding.
+    Uses charset-normalizer. Fallbacks to detect_encoding.
     """
     assert isinstance(string, bytes)
     try:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import cchardet
+import charset_normalizer as cchardet
 import six
 
 from talon import utils as u


### PR DESCRIPTION
This pull request updates the character encoding detection library used in the project, replacing `cchardet` with `charset-normalizer` throughout the codebase. This change affects both dependencies and import statements, as well as documentation and comments.

**Dependency and import updates:**

* Replaced the `cchardet` dependency with `charset-normalizer` in the `setup.py` requirements list, and updated related comments to indicate the change.
* Updated import statements in `talon/utils.py` and `tests/utils_test.py` to use `charset_normalizer` (aliased as `cchardet` for compatibility with existing code). [[1]](diffhunk://#diff-032ca51cccc900d23350950086c8ef87816da85b232eed27a515a91ace8b1e24L7-R7) [[2]](diffhunk://#diff-c1b8915c792156c4afeadff18c91d5dc762d332348bb00a47232777100a1ef47L5-R5)

**Documentation and comments:**

* Updated the docstring in `quick_detect_encoding` to reflect the use of `charset-normalizer` instead of `cchardet`.